### PR TITLE
Route parse fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem "rake"
+gem "pry"
 
 group :test do
   gem "coveralls", "~> 0.7.0", require: false

--- a/lib/supercamp/criteria/abstract.rb
+++ b/lib/supercamp/criteria/abstract.rb
@@ -2,7 +2,7 @@ module Supercamp
   module Criteria
 
     class Abstract
-      
+
       attr_reader   :options
       attr_writer   :response
 
@@ -24,8 +24,8 @@ module Supercamp
       end
 
       def endpoint
-        name = self.class.to_s.split("::").last.downcase
-        "#{Supercamp.config.base_url}/#{name}s"
+        name = self.route_end
+        "#{Supercamp.config.base_url}#{name}"
       end
 
       def query

--- a/lib/supercamp/criteria/abstract.rb
+++ b/lib/supercamp/criteria/abstract.rb
@@ -30,10 +30,10 @@ module Supercamp
 
       def query
         opts = { api_key: Supercamp.config.api_key }.merge(options)
-        Typhoeus::Request.new(endpoint, timeout: Supercamp.config.timeout, params: opts, follow_location: true)
+        Typhoeus::Request.new(endpoint, timeout: Supercamp.config.timeout, params: opts, followlocation: true)
       end
 
-      def response(query=query)
+      def response(query=self.query)
         return @response unless @response.nil?
         response = query.run
         if response.code == 200

--- a/lib/supercamp/criteria/abstract.rb
+++ b/lib/supercamp/criteria/abstract.rb
@@ -30,7 +30,7 @@ module Supercamp
 
       def query
         opts = { api_key: Supercamp.config.api_key }.merge(options)
-        Typhoeus::Request.new(endpoint, timeout: Supercamp.config.timeout, params: opts)
+        Typhoeus::Request.new(endpoint, timeout: Supercamp.config.timeout, params: opts, follow_location: true)
       end
 
       def response(query=query)

--- a/lib/supercamp/criteria/campground.rb
+++ b/lib/supercamp/criteria/campground.rb
@@ -19,8 +19,12 @@ module Supercamp
         "winter_activities" => 4013
       }
 
+      def route_end
+        "/campgrounds"
+      end
+
       # landmarkLat, landmarkLong (latitude/longitude)
-      # 
+      #
       # These two parameters allow for campground searches around a fixed geo-point.
       #
       def geo(lat, lng)
@@ -32,7 +36,7 @@ module Supercamp
 
       # pstate: State or Province
       #
-      # The two character abbreviation for US state 
+      # The two character abbreviation for US state
       #
       def state(abbr)
         merge_option(:pstate, abbr)
@@ -42,9 +46,9 @@ module Supercamp
 
       # pname: Park Name
       #
-      # The name of the park.  When this parameter is specified, 
-      # the API performs a string-match query for parks containing 
-      # the character string specified. 
+      # The name of the park.  When this parameter is specified,
+      # the API performs a string-match query for parks containing
+      # the character string specified.
       #
       def name(park)
         merge_option(:pname, park)
@@ -67,10 +71,10 @@ module Supercamp
       # has: Campture Features
       #
       # Specify 1 or more optional perks:
-      # # water     
-      # # sewer     
-      # # pull      
-      # # pets      
+      # # water
+      # # sewer
+      # # pull
+      # # pets
       # # waterfront
       #
       def has(*perks)

--- a/lib/supercamp/criteria/campsite.rb
+++ b/lib/supercamp/criteria/campsite.rb
@@ -17,7 +17,7 @@ module Supercamp
 
       PERKS = {
         "water"       => 3007,
-        "sewer"       => 3007, 
+        "sewer"       => 3007,
         "pull"        => 3008,
         "pets"        => 3010,
         "waterfront"  => 3011
@@ -30,9 +30,12 @@ module Supercamp
         "50" => 3005
       }
 
+      def route_end
+        "/campsites"
+      end
 
       # siteType
-      # 
+      #
       # If unspecified, all site types are returned.
       #
       def site_type(name)
@@ -54,8 +57,8 @@ module Supercamp
 
       # lengthOfStay: Length of Stay
       #
-      # When combined with arvdate, this parameter determines how long 
-      # the camper would like to reserve the campground. 
+      # When combined with arvdate, this parameter determines how long
+      # the camper would like to reserve the campground.
       #
       def nights(amt)
         merge_option("lengthOfStay", amt)
@@ -65,7 +68,7 @@ module Supercamp
 
       # eqplen: Equipment Length
       #
-      # If the camper wants to find campgrounds where his 50 foot RV will fit, 
+      # If the camper wants to find campgrounds where his 50 foot RV will fit,
       # issue a query where eqplen=50
       #
       def min_equip_length(val)
@@ -73,7 +76,7 @@ module Supercamp
         self
       end
 
-      
+
       # Maxpeople: Number of campers
       #
       #

--- a/lib/supercamp/criteria/campsite.rb
+++ b/lib/supercamp/criteria/campsite.rb
@@ -34,6 +34,17 @@ module Supercamp
         "/campsites"
       end
 
+      # Contract code and id from details because it is not needed
+      # For 2017 baby
+      def contract_code(type)
+        merge_option("contractCode", type)
+        self
+      end
+
+      def id(val)
+        merge_option("parkId", val)
+        self
+      end
       # siteType
       #
       # If unspecified, all site types are returned.

--- a/lib/supercamp/criteria/detail.rb
+++ b/lib/supercamp/criteria/detail.rb
@@ -3,10 +3,14 @@ module Supercamp
 
     class Detail < Abstract
 
+      def route_end
+        "/campground/details"
+      end
+
       # contractCode: STATE, FEDERAL or PRIVATE
 
-      # "contractCode" is a syonym for contractID, which is what is returned by 
-      # the Campground Search API.  It specifies the jurisdiction for the campground.  
+      # "contractCode" is a syonym for contractID, which is what is returned by
+      # the Campground Search API.  It specifies the jurisdiction for the campground.
       # This parameter must be used in conjuction with parkId
       #
       def contract_code(type)
@@ -17,7 +21,7 @@ module Supercamp
 
       # parkId: Facility ID
 
-      # "parkId" is a synonym for "facilityID", which is returned by the Campground Search API.  
+      # "parkId" is a synonym for "facilityID", which is returned by the Campground Search API.
       # It is a unique identifier for the campground.
       #
       def id(val)

--- a/lib/supercamp/criteria/detail.rb
+++ b/lib/supercamp/criteria/detail.rb
@@ -17,8 +17,6 @@ module Supercamp
         merge_option("contractCode", type)
         self
       end
-
-
       # parkId: Facility ID
 
       # "parkId" is a synonym for "facilityID", which is returned by the Campground Search API.

--- a/lib/supercamp/response.rb
+++ b/lib/supercamp/response.rb
@@ -22,7 +22,9 @@ module Supercamp
 
     def parse_response(xml)
       xml.gsub!("\n", "")
-      Oga.parse_xml(xml).children.first.name
+      parsed = Oga.parse_xml(xml)
+      toplevel = parsed.children.first.name
+      parsed.xpath(toplevel).first
     end
 
     def set_results_count(parsed)

--- a/lib/supercamp/response.rb
+++ b/lib/supercamp/response.rb
@@ -18,15 +18,19 @@ module Supercamp
     end
 
 
-  private
+    private
 
     def parse_response(xml)
       xml.gsub!("\n", "")
-      Oga.parse_xml(xml).xpath("resultset").first
+      Oga.parse_xml(xml).children.first.name
     end
 
     def set_results_count(parsed)
-      @count = parsed.attribute("count").value.to_i
+      if parsed.attribute("count")
+        @count = parsed.attribute("count").value.to_i
+      else
+        @count = 0
+      end
     end
 
     def set_entries(parsed)

--- a/lib/supercamp/version.rb
+++ b/lib/supercamp/version.rb
@@ -1,3 +1,3 @@
 module Supercamp
-  VERSION = "0.0.3"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
Hello friend! 

We're using this wrapper for our campsite database and had some issues targeting details and campsites. 

*  include contract_code and id to campsite as required by api
* adjust typheous request to follow redirect
* adjust route parser to target the first xml element as 'resultset' is depreacted in Detail/Campsite search

Best regards!